### PR TITLE
Incorporated brummer's feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,26 @@ GxPlugins.lv2 is a set of extra standalone lv2 plugins designed to compliment th
 ## Plugin Summary
 
 #### Overdrive
-* GxBottleRocket.lv2 - Based on the ![Mesa V1 Bottle Rocket](http://mesaboogie.com/support/out-of-production/v-1-bottle-rocket.html) tube overdrive
-* GxDOP250.lv2 - Based on the ![Analog Man DOD OD-250 Yellow Overdrive](https://www.buyanalogman.com/DOD_OD_250_p/am-dod-250.htm)
-* GxGuvnor.lv2 - Based on the ![Marshall "The Guv'nor" Overdrive](https://marshall.com/marshall-amps/products/pedals/gv-2-guvnor-plus)
-* GxHotBox.lv2 - Based on the ![Matchless Hot Box](http://matchlessamplifiers.com/pedals/hotbox-iii) tube overdrive
-* GxSD1.lv2 - Based on the ![Boss SD-1 Super Overdrive](https://www.boss.info/us/products/sd-1/)
-* GxSD2Lead.lv2 - Based on the ![Boss SD-2 Dual Overdrive](http://www.bossarea.com/boss-sd-2-dual-overdrive/)
+* GxBottleRocket.lv2 - Based on the [Mesa V1 Bottle Rocket](http://mesaboogie.com/support/out-of-production/v-1-bottle-rocket.html) tube overdrive
+* GxDOP250.lv2 - Based on the [Analog Man DOD OD-250 Yellow Overdrive](https://www.buyanalogman.com/DOD_OD_250_p/am-dod-250.htm)
+* GxGuvnor.lv2 - Based on the [Marshall "The Guv'nor" Overdrive](https://marshall.com/marshall-amps/products/pedals/gv-2-guvnor-plus)
+* GxHotBox.lv2 - Based on the [Matchless Hot Box](http://matchlessamplifiers.com/pedals/hotbox-iii) tube overdrive
+* GxSD1.lv2 - Based on the [Boss SD-1 Super Overdrive](https://www.boss.info/us/products/sd-1/)
+* GxSD2Lead.lv2 - Based on the [Boss SD-2 Dual Overdrive](http://www.bossarea.com/boss-sd-2-dual-overdrive/)
 
 #### Fuzz/Distortion
-* GxAxisFace.lv2 - Based on the ![Axis Face Silicon](http://fuzzcentral.ssguitar.com/axisface.php) fuzz
-* GxFz1b.lv2 - Based on the Robert Moog-designed ![Maestro FZ-1B](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone) fuzz
-* GxFz1s.lv2 - Based on the ![Maestro FZ-1S Super-Fuzz](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone)
+* GxAxisFace.lv2 - Based on the [Axis Face Silicon](http://fuzzcentral.ssguitar.com/axisface.php) fuzz
+* GxFz1b.lv2 - Based on the Robert Moog-designed [Maestro FZ-1B](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone) fuzz
+* GxFz1s.lv2 - Based on the [Maestro FZ-1S Super-Fuzz](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone)
 * GxHyperion.lv2 - Based on the Devi Ever FX Hyperion fuzz
-* GxHeathkit.lv2 - Based on the ![Heathkit TA-28](http://harmony.demont.net/heathkit.php) distortion/booster/fuzz
-* GxKnightFuzz.lv2 - Based on the ![Basic Audio Knight Fuzz](http://www.basicaudio.net/pedal-details.php?pedal=30) fuzz
-* GxLiquidDrive.lv2 - Based on the ![Liquid Drive](http://fuzzcentral.ssguitar.com/liquid.php) fuzz, a modified ![Ross Distortion](http://www.home-wrecker.com/ross.html)
-* GxSuppaToneBender.lv2 - Based on the ![Colorsound Supa Tonebender](https://en.wikipedia.org/wiki/Tone_Bender) which, in turn, is based on the ![Electro-Harmonix Big Muff π](https://en.wikipedia.org/wiki/Big_Muff)
-* GxSaturator.lv2 - Based on the Joe Satriani-specified ![Vox Satchurator](https://www.joesatrianiuniverse.com/gear/vox-js-pedals/satchurator/) distortion
-* GxSunFace.lv2 - Based on the ![Analog Man Sun Face](http://www.analogman.com/fuzzface.htm) fuzz
-* GxSuperFuzz.lv2 - Based on the ![Univox Super-Fuzz](https://en.wikipedia.org/wiki/Univox_Super-Fuzz)
-* GxToneMachine.lv2 - Based on the ![Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm) fuzz
+* GxHeathkit.lv2 - Based on the [Heathkit TA-28](http://harmony.demont.net/heathkit.php) distortion/booster/fuzz
+* GxKnightFuzz.lv2 - Based on the [Basic Audio Knight Fuzz](http://www.basicaudio.net/pedal-details.php?pedal=30) fuzz
+* GxLiquidDrive.lv2 - Based on the [Liquid Drive](http://fuzzcentral.ssguitar.com/liquid.php) fuzz, a modified ![Ross Distortion](http://www.home-wrecker.com/ross.html)
+* GxSuppaToneBender.lv2 - Based on the [Colorsound Supa Tonebender](https://en.wikipedia.org/wiki/Tone_Bender) which, in turn, is based on the [Electro-Harmonix Big Muff π](https://en.wikipedia.org/wiki/Big_Muff)
+* GxSaturator.lv2 - Based on the Joe Satriani-specified [Vox Satchurator](https://www.joesatrianiuniverse.com/gear/vox-js-pedals/satchurator/) distortion
+* GxSunFace.lv2 - Based on the [Analog Man Sun Face](http://www.analogman.com/fuzzface.htm) fuzz
+* GxSuperFuzz.lv2 - Based on the [Univox Super-Fuzz](https://en.wikipedia.org/wiki/Univox_Super-Fuzz)
+* GxToneMachine.lv2 - Based on the [Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm) fuzz
 * GxTubeDistortion.lv2 - Unknown... need input from brummer
 * GxVintageFuzzMaster.lv2 - Based on the Devi Ever Vintage Fuzz Master
 * GxVoodoFuzz.lv2 - Unknown... (doesn't look much like a Joyo Voodoo Octave Fuzz)... need input from brummer
@@ -31,13 +31,13 @@ GxPlugins.lv2 is a set of extra standalone lv2 plugins designed to compliment th
 #### Amplifiers
 * GxMicroAmp.lv2 - A simple booster 
 * GxVBassPreAmp.lv2 - A bass preamp
-* GxSVT.lv2 - 
+* GxSVT.lv2 - Based on the [Ampeg SVT-CL Bass Head](https://ampeg.com/products/classic/svtcl/) 
 * GxVmk2.lv2 - Unknown... need input from brummer
-* GxUvox720k - Based on ![Vox-style amps](https://www.voxamps.com), probably the ![JMI Vox UL730](http://www.voxshowroom.com/uk/amp/730.html)... need input from brummer
+* GxUvox720k - Based on [Vox-style amps](https://www.voxamps.com), probably the ![JMI Vox UL730](http://www.voxshowroom.com/uk/amp/730.html)... need input from brummer
 
 #### Other
 * GxQuack.lv2 - Autowah
-* GxSlowGear.lv2 - Based on the ![Boss Gx SlowGear](http://www.bossarea.com/boss-sg-1-slow-gear/), attack-smoothing, auto-swelling pedal of the early 80s
+* GxSlowGear.lv2 - Based on the [Boss Gx SlowGear](http://www.bossarea.com/boss-sg-1-slow-gear/), attack-smoothing, auto-swelling pedal of the early 80s
 
 ###### Build and installation
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ GxPlugins.lv2 is a set of extra standalone lv2 plugins designed to compliment th
 * GxVBassPreAmp.lv2 - A bass preamp
 * GxSVT.lv2 - Based on the [Ampeg SVT-CL Bass Head](https://ampeg.com/products/classic/svtcl/) 
 * GxVmk2.lv2 - Unknown... need input from brummer
-* GxUvox720k - Based on [Vox-style amps](https://www.voxamps.com), probably the ![JMI Vox UL730](http://www.voxshowroom.com/uk/amp/730.html)... need input from brummer
+* GxUvox720k - Based on [Vox-style amps](https://www.voxamps.com), probably the [JMI Vox UL730](http://www.voxshowroom.com/uk/amp/730.html)... need input from brummer
 
 #### Other
 * GxQuack.lv2 - Autowah

--- a/README.md
+++ b/README.md
@@ -1,7 +1,70 @@
 # GxPlugins.lv2
-A set of extra lv2 plugins from the guitarix project.
+GxPlugins.lv2 is a set of extra standalone lv2 plugins designed to compliment the Guitarix project. Each plugin exists as its own submodule under this repository.
 
-This repository contain the following extra GxPlugins as submodules.
+## Plugin Summary
+
+#### Overdrive
+* GxBottleRocket.lv2 - Based on the ![Mesa V1 Bottle Rocket](http://mesaboogie.com/support/out-of-production/v-1-bottle-rocket.html) tube overdrive
+* GxDOP250.lv2 - Based on the ![Analog Man DOD OD-250 Yellow Overdrive](https://www.buyanalogman.com/DOD_OD_250_p/am-dod-250.htm)
+* GxGuvnor.lv2 - Based on the ![Marshall "The Guv'nor" Overdrive](https://marshall.com/marshall-amps/products/pedals/gv-2-guvnor-plus)
+* GxHotBox.lv2 - Based on the ![Matchless Hot Box](http://matchlessamplifiers.com/pedals/hotbox-iii) tube overdrive
+* GxSD1.lv2 - Based on the ![Boss SD-1 Super Overdrive](https://www.boss.info/us/products/sd-1/)
+* GxSD2Lead.lv2 - Based on the ![Boss SD-2 Dual Overdrive](http://www.bossarea.com/boss-sd-2-dual-overdrive/)
+
+#### Fuzz/Distortion
+* GxAxisFace.lv2 - Based on the ![Axis Face Silicon](http://fuzzcentral.ssguitar.com/axisface.php) fuzz
+* GxFz1b.lv2 - Based on the Robert Moog-designed ![Maestro FZ-1B](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone) fuzz
+* GxFz1s.lv2 - Based on the ![Maestro FZ-1S Super-Fuzz](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone)
+* GxHyperion.lv2 - Based on the Devi Ever FX Hyperion fuzz
+* GxHeathkit.lv2 - Based on the ![Heathkit TA-28](http://harmony.demont.net/heathkit.php) distortion/booster/fuzz
+* GxKnightFuzz.lv2 - Based on the ![Basic Audio Knight Fuzz](http://www.basicaudio.net/pedal-details.php?pedal=30) fuzz
+* GxLiquidDrive.lv2 - Based on the ![Liquid Drive](http://fuzzcentral.ssguitar.com/liquid.php) fuzz, a modified ![Ross Distortion](http://www.home-wrecker.com/ross.html)
+* GxSuppaToneBender.lv2 - Based on the ![Colorsound Supa Tonebender](https://en.wikipedia.org/wiki/Tone_Bender) which, in turn, is based on the ![Electro-Harmonix Big Muff π](https://en.wikipedia.org/wiki/Big_Muff)
+* GxSaturator.lv2 - Based on the Joe Satriani-specified ![Vox Satchurator](https://www.joesatrianiuniverse.com/gear/vox-js-pedals/satchurator/) distortion
+* GxSunFace.lv2 - Based on the ![Analog Man Sun Face](http://www.analogman.com/fuzzface.htm) fuzz
+* GxSuperFuzz.lv2 - Based on the ![Univox Super-Fuzz](https://en.wikipedia.org/wiki/Univox_Super-Fuzz)
+* GxToneMachine.lv2 - Based on the ![Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm) fuzz
+* GxTubeDistortion.lv2 - Unknown... need input from brummer
+* GxVintageFuzzMaster.lv2 - Based on the Devi Ever Vintage Fuzz Master
+* GxVoodoFuzz.lv2 - Unknown... (doesn't look much like a Joyo Voodoo Octave Fuzz)... need input from brummer
+
+#### Amplifiers
+* GxMicroAmp.lv2 - A simple booster 
+* GxVBassPreAmp.lv2 - A bass preamp
+* GxSVT.lv2 - 
+* GxVmk2.lv2 - Unknown... need input from brummer
+* GxUvox720k - Based on ![Vox-style amps](https://www.voxamps.com), probably the ![JMI Vox UL730](http://www.voxshowroom.com/uk/amp/730.html)... need input from brummer
+
+#### Other
+* GxQuack.lv2 - Autowah
+* GxSlowGear.lv2 - Based on the ![Boss Gx SlowGear](http://www.bossarea.com/boss-sg-1-slow-gear/), attack-smoothing, auto-swelling pedal of the early 80s
+
+###### Build and installation
+
+Dependencies:
+- libc6-dev
+- libcairo2-dev
+- libx11-dev
+- x11proto-dev
+- lv2-dev
+
+On Ubuntu/Debian: 
+```
+sudo apt install libc6-dev libcairo2-dev libx11-dev x11proto-dev lv2-dev
+```
+NOTE: These packages may have different names on different distributions. GxPlugins.lv2 has no configure script, so make will simply fail when one of these packages isn't found.
+
+## Build 
+
+```
+git submodule init
+git submodule update
+make
+make install # will install into ~/.lv2 ... AND/OR....
+sudo make install # will install into /usr/lib/lv2
+```
+
+## Images
 
 ###### GxBottleRocket.lv2
 ![GxBottleRocket](https://github.com/brummer10/GxBottleRocket.lv2/raw/master/GxBottleRocket.png)
@@ -60,43 +123,11 @@ This repository contain the following extra GxPlugins as submodules.
 ###### GxMicroAmp.lv2
 ![GxMicroAmp](https://raw.githubusercontent.com/brummer10/GxMicroAmp.lv2/master/GxMicroAmp.png)
 
-###### BUILD DEPENDENCY’S 
+## Debian package
 
-the following packages are needed to build the GxPlugs:
+You can build a Debian package directly with:
+```
+dpkg-buildpackage -rfakeroot -uc -us -b
+```
 
-- libc6-dev
-- libcairo2-dev
-- libx11-dev
-- x11proto-dev
-- lv2-dev
-
-note that those packages could have different, but similar names 
-on different distributions. There is no configure script, 
-make will simply fail when one of those packages isn't found.
-
-## BUILD 
-
-$ git submodule init
-
-$ git submodule update
-
-$ make
-
-$ make install
-
-will install into ~/.lv2
-
-$ sudo make install
-
-will install into /usr/lib/lv2
-
-## Debian
-
-You could build a debian package directly with the following command:
-
-$ dpkg-buildpackage -rfakeroot -uc -us -b
-
-(*) Other product names modeled in this software are trademarks 
-of their respective companies that do not endorse and are not associated 
-or affiliated with this simulation. 
-All other trademarks are the property of their respective holders.
+NOTE: Other product names modeled in this software are trademarks of their respective companies that do not endorse and are not associated or affiliated with this simulation. All other trademarks are the property of their respective holders.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ GxPlugins.lv2 is a set of extra standalone lv2 plugins designed to compliment th
 
 ## Plugin Summary
 
+*Disclaimer* The product names modeled in this software are trademarks of their respective companies that do not endorse and are not associated or affiliated with this simulation. All trademarks are the property of their respective holders.
+
 #### Overdrive
 * GxBottleRocket.lv2 - Based on the [Mesa V1 Bottle Rocket](http://mesaboogie.com/support/out-of-production/v-1-bottle-rocket.html) tube overdrive
 * GxDOP250.lv2 - Based on the [Analog Man DOD OD-250 Yellow Overdrive](https://www.buyanalogman.com/DOD_OD_250_p/am-dod-250.htm)
@@ -24,15 +26,15 @@ GxPlugins.lv2 is a set of extra standalone lv2 plugins designed to compliment th
 * GxSunFace.lv2 - Based on the [Analog Man Sun Face](http://www.analogman.com/fuzzface.htm) fuzz
 * GxSuperFuzz.lv2 - Based on the [Univox Super-Fuzz](https://en.wikipedia.org/wiki/Univox_Super-Fuzz)
 * GxToneMachine.lv2 - Based on the [Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm) fuzz
-* GxTubeDistortion.lv2 - Unknown... need input from brummer
+* GxTubeDistortion.lv2 - Generic tube distortion based on http://www.montagar.com/~patj/tubedist.gif
 * GxVintageFuzzMaster.lv2 - Based on the Devi Ever Vintage Fuzz Master
-* GxVoodoFuzz.lv2 - Unknown... (doesn't look much like a Joyo Voodoo Octave Fuzz)... need input from brummer
+* GxVoodoFuzz.lv2 - Based on the [Voodoo Lab SuperFuzz](http://www.voodoolab.com/superfuzz.htm). It's basically a Bosstone circuit, followed by the tone control of the [Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm) in parralel with a [Devi Ever Dark Boost](https://reverb.com/p/devi-ever-fx-dark-boost).
 
 #### Amplifiers
 * GxMicroAmp.lv2 - A simple booster 
-* GxVBassPreAmp.lv2 - A bass preamp
+* GxVBassPreAmp.lv2 - Simulation of the 1984 [Vox Venue Bass 100 Pre Amp](https://www.korguk.com/voxcircuits/) section
 * GxSVT.lv2 - Based on the [Ampeg SVT-CL Bass Head](https://ampeg.com/products/classic/svtcl/) 
-* GxVmk2.lv2 - Unknown... need input from brummer
+* GxVmk2.lv2 - Based on Vox MKII solid state preamp of the late 60s
 * GxUvox720k - Based on [Vox-style amps](https://www.voxamps.com), probably the [JMI Vox UL730](http://www.voxshowroom.com/uk/amp/730.html)... need input from brummer
 
 #### Other
@@ -62,6 +64,12 @@ git submodule update
 make
 make install # will install into ~/.lv2 ... AND/OR....
 sudo make install # will install into /usr/lib/lv2
+```
+## Debian package
+
+You can build a Debian package directly with:
+```
+dpkg-buildpackage -rfakeroot -uc -us -b
 ```
 
 ## Images
@@ -122,12 +130,3 @@ sudo make install # will install into /usr/lib/lv2
 ![GxTubeDistortion](https://raw.githubusercontent.com/brummer10/GxTubeDistortion.lv2/master/GxTubeDistortion.png)
 ###### GxMicroAmp.lv2
 ![GxMicroAmp](https://raw.githubusercontent.com/brummer10/GxMicroAmp.lv2/master/GxMicroAmp.png)
-
-## Debian package
-
-You can build a Debian package directly with:
-```
-dpkg-buildpackage -rfakeroot -uc -us -b
-```
-
-NOTE: Other product names modeled in this software are trademarks of their respective companies that do not endorse and are not associated or affiliated with this simulation. All other trademarks are the property of their respective holders.

--- a/README.md
+++ b/README.md
@@ -5,40 +5,42 @@ GxPlugins.lv2 is a set of extra standalone lv2 plugins designed to compliment th
 
 *Disclaimer* The product names modeled in this software are trademarks of their respective companies that do not endorse and are not associated or affiliated with this simulation. All trademarks are the property of their respective holders.
 
+✝ = Includes master bypass
+
 #### Overdrive
-* GxBottleRocket.lv2 - Based on the [Mesa V1 Bottle Rocket](http://mesaboogie.com/support/out-of-production/v-1-bottle-rocket.html) tube overdrive
-* GxDOP250.lv2 - Based on the [Analog Man DOD OD-250 Yellow Overdrive](https://www.buyanalogman.com/DOD_OD_250_p/am-dod-250.htm)
+* GxBottleRocket.lv2<sup>✝</sup> - Based on the [Mesa V1 Bottle Rocket](http://mesaboogie.com/support/out-of-production/v-1-bottle-rocket.html) tube overdrive
+* GxDOP250.lv2<sup>✝</sup> - Based on the [Analog Man DOD OD-250 Yellow Overdrive](https://www.buyanalogman.com/DOD_OD_250_p/am-dod-250.htm)
 * GxGuvnor.lv2 - Based on the [Marshall "The Guv'nor" Overdrive](https://marshall.com/marshall-amps/products/pedals/gv-2-guvnor-plus)
-* GxHotBox.lv2 - Based on the [Matchless Hot Box](http://matchlessamplifiers.com/pedals/hotbox-iii) tube overdrive
-* GxSD1.lv2 - Based on the [Boss SD-1 Super Overdrive](https://www.boss.info/us/products/sd-1/)
-* GxSD2Lead.lv2 - Based on the [Boss SD-2 Dual Overdrive](http://www.bossarea.com/boss-sd-2-dual-overdrive/)
+* GxHotBox.lv2<sup>✝</sup> - Based on the [Matchless Hot Box](http://matchlessamplifiers.com/pedals/hotbox-iii) tube overdrive
+* GxSD1.lv2<sup>✝</sup> - Based on the [Boss SD-1 Super Overdrive](https://www.boss.info/us/products/sd-1/)
+* GxSD2Lead.lv2<sup>✝</sup> - Based on the [Boss SD-2 Dual Overdrive](http://www.bossarea.com/boss-sd-2-dual-overdrive/)
 
 #### Fuzz/Distortion
-* GxAxisFace.lv2 - Based on the [Axis Face Silicon](http://fuzzcentral.ssguitar.com/axisface.php) fuzz
-* GxFz1b.lv2 - Based on the Robert Moog-designed [Maestro FZ-1B](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone) fuzz
-* GxFz1s.lv2 - Based on the [Maestro FZ-1S Super-Fuzz](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone)
+* GxAxisFace.lv2<sup>✝</sup> - Based on the [Axis Face Silicon](http://fuzzcentral.ssguitar.com/axisface.php) fuzz
+* GxFz1b.lv2<sup>✝</sup> - Based on the Robert Moog-designed [Maestro FZ-1B](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone) fuzz
+* GxFz1s.lv2<sup>✝</sup> - Based on the [Maestro FZ-1S Super-Fuzz](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone)
 * GxHyperion.lv2 - Based on the Devi Ever FX Hyperion fuzz
-* GxHeathkit.lv2 - Based on the [Heathkit TA-28](http://harmony.demont.net/heathkit.php) distortion/booster/fuzz
-* GxKnightFuzz.lv2 - Based on the [Basic Audio Knight Fuzz](http://www.basicaudio.net/pedal-details.php?pedal=30) fuzz
-* GxLiquidDrive.lv2 - Based on the [Liquid Drive](http://fuzzcentral.ssguitar.com/liquid.php) fuzz, a modified [Ross Distortion](http://www.home-wrecker.com/ross.html)
+* GxHeathkit.lv2<sup>✝</sup> - Based on the [Heathkit TA-28](http://harmony.demont.net/heathkit.php) distortion/booster/fuzz
+* GxKnightFuzz.lv2<sup>✝</sup> - Based on the [Basic Audio Knight Fuzz](http://www.basicaudio.net/pedal-details.php?pedal=30) fuzz
+* GxLiquidDrive.lv2<sup>✝</sup> - Based on the [Liquid Drive](http://fuzzcentral.ssguitar.com/liquid.php) fuzz, a modified [Ross Distortion](http://www.home-wrecker.com/ross.html)
 * GxSuppaToneBender.lv2 - Based on the [Colorsound Supa Tonebender](https://en.wikipedia.org/wiki/Tone_Bender) which, in turn, is based on the [Electro-Harmonix Big Muff π](https://en.wikipedia.org/wiki/Big_Muff)
 * GxSaturator.lv2 - Based on the Joe Satriani-specified [Vox Satchurator](https://www.joesatrianiuniverse.com/gear/vox-js-pedals/satchurator/) distortion
-* GxSunFace.lv2 - Based on the [Analog Man Sun Face](http://www.analogman.com/fuzzface.htm) fuzz
+* GxSunFace.lv2<sup>✝</sup> - Based on the [Analog Man Sun Face](http://www.analogman.com/fuzzface.htm) fuzz
 * GxSuperFuzz.lv2 - Based on the [Univox Super-Fuzz](https://en.wikipedia.org/wiki/Univox_Super-Fuzz)
 * GxToneMachine.lv2 - Based on the [Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm) fuzz
-* GxTubeDistortion.lv2 - Generic tube distortion based on http://www.montagar.com/~patj/tubedist.gif
+* GxTubeDistortion.lv2<sup>✝</sup> - Generic tube distortion based on http://www.montagar.com/~patj/tubedist.gif
 * GxVintageFuzzMaster.lv2 - Based on the Devi Ever Vintage Fuzz Master
 * GxVoodoFuzz.lv2 - Based on the [Voodoo Lab SuperFuzz](http://www.voodoolab.com/superfuzz.htm). It's basically a Bosstone circuit, followed by the tone control of the [Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm) in parralel with a [Devi Ever Dark Boost](https://reverb.com/p/devi-ever-fx-dark-boost).
 
 #### Amplifiers
-* GxMicroAmp.lv2 - A simple booster 
-* GxVBassPreAmp.lv2 - Simulation of the 1984 [Vox Venue Bass 100 Pre Amp](https://www.korguk.com/voxcircuits/) section
-* GxSVT.lv2 - Based on the [Ampeg SVT-CL Bass Head](https://ampeg.com/products/classic/svtcl/) 
+* GxMicroAmp.lv2<sup>✝</sup> - A simple booster 
+* GxVBassPreAmp.lv2<sup>✝</sup> - Simulation of the 1984 [Vox Venue Bass 100 Pre Amp](https://www.korguk.com/voxcircuits/) section
+* GxSVT.lv2<sup>✝</sup> - Based on the [Ampeg SVT-CL Bass Head](https://ampeg.com/products/classic/svtcl/) 
 * GxVmk2.lv2 - Based on Vox MKII solid state preamp of the late 60s
 * GxUvox720k - Based on [Vox-style amps](https://www.voxamps.com), probably the [JMI Vox UL730](http://www.voxshowroom.com/uk/amp/730.html)... need input from brummer
 
 #### Other
-* GxQuack.lv2 - Autowah
+* GxQuack.lv2<sup>✝</sup> - Autowah
 * GxSlowGear.lv2 - Based on the [Boss Gx SlowGear](http://www.bossarea.com/boss-sg-1-slow-gear/), attack-smoothing, auto-swelling pedal of the early 80s
 
 ###### Build and installation

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GxPlugins.lv2 is a set of extra standalone lv2 plugins designed to compliment th
 * GxHyperion.lv2 - Based on the Devi Ever FX Hyperion fuzz
 * GxHeathkit.lv2 - Based on the [Heathkit TA-28](http://harmony.demont.net/heathkit.php) distortion/booster/fuzz
 * GxKnightFuzz.lv2 - Based on the [Basic Audio Knight Fuzz](http://www.basicaudio.net/pedal-details.php?pedal=30) fuzz
-* GxLiquidDrive.lv2 - Based on the [Liquid Drive](http://fuzzcentral.ssguitar.com/liquid.php) fuzz, a modified ![Ross Distortion](http://www.home-wrecker.com/ross.html)
+* GxLiquidDrive.lv2 - Based on the [Liquid Drive](http://fuzzcentral.ssguitar.com/liquid.php) fuzz, a modified [Ross Distortion](http://www.home-wrecker.com/ross.html)
 * GxSuppaToneBender.lv2 - Based on the [Colorsound Supa Tonebender](https://en.wikipedia.org/wiki/Tone_Bender) which, in turn, is based on the [Electro-Harmonix Big Muff π](https://en.wikipedia.org/wiki/Big_Muff)
 * GxSaturator.lv2 - Based on the Joe Satriani-specified [Vox Satchurator](https://www.joesatrianiuniverse.com/gear/vox-js-pedals/satchurator/) distortion
 * GxSunFace.lv2 - Based on the [Analog Man Sun Face](http://www.analogman.com/fuzzface.htm) fuzz

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ GxPlugins.lv2 is a set of extra standalone lv2 plugins designed to compliment th
 ## Plugin Summary
 
 ✝ = Includes master bypass
+
 &ast; = The product names modeled in this software are trademarks of their respective companies that do not endorse and are not associated or affiliated with this simulation. All trademarks are the property of their respective holders.
 
 #### Overdrive

--- a/README.md
+++ b/README.md
@@ -3,45 +3,44 @@ GxPlugins.lv2 is a set of extra standalone lv2 plugins designed to compliment th
 
 ## Plugin Summary
 
-*Disclaimer* The product names modeled in this software are trademarks of their respective companies that do not endorse and are not associated or affiliated with this simulation. All trademarks are the property of their respective holders.
-
 ✝ = Includes master bypass
+&ast; = The product names modeled in this software are trademarks of their respective companies that do not endorse and are not associated or affiliated with this simulation. All trademarks are the property of their respective holders.
 
 #### Overdrive
-* GxBottleRocket.lv2<sup>✝</sup> - Based on the [Mesa V1 Bottle Rocket](http://mesaboogie.com/support/out-of-production/v-1-bottle-rocket.html) tube overdrive
-* GxDOP250.lv2<sup>✝</sup> - Based on the [Analog Man DOD OD-250 Yellow Overdrive](https://www.buyanalogman.com/DOD_OD_250_p/am-dod-250.htm)
-* GxGuvnor.lv2 - Based on the [Marshall "The Guv'nor" Overdrive](https://marshall.com/marshall-amps/products/pedals/gv-2-guvnor-plus)
-* GxHotBox.lv2<sup>✝</sup> - Based on the [Matchless Hot Box](http://matchlessamplifiers.com/pedals/hotbox-iii) tube overdrive
-* GxSD1.lv2<sup>✝</sup> - Based on the [Boss SD-1 Super Overdrive](https://www.boss.info/us/products/sd-1/)
-* GxSD2Lead.lv2<sup>✝</sup> - Based on the [Boss SD-2 Dual Overdrive](http://www.bossarea.com/boss-sd-2-dual-overdrive/)
+* GxBottleRocket.lv2<sup>✝</sup> - Based on the [Mesa V1 Bottle Rocket](http://mesaboogie.com/support/out-of-production/v-1-bottle-rocket.html)&ast; tube overdrive
+* GxDOP250.lv2<sup>✝</sup> - Based on the [Analog Man DOD OD-250 Yellow Overdrive](https://www.buyanalogman.com/DOD_OD_250_p/am-dod-250.htm)&ast;
+* GxGuvnor.lv2 - Based on the [Marshall "The Guv'nor" Overdrive](https://marshall.com/marshall-amps/products/pedals/gv-2-guvnor-plus)&ast;
+* GxHotBox.lv2<sup>✝</sup> - Based on the [Matchless Hot Box](http://matchlessamplifiers.com/pedals/hotbox-iii)&ast; tube overdrive
+* GxSD1.lv2<sup>✝</sup> - Based on the [Boss SD-1 Super Overdrive](https://www.boss.info/us/products/sd-1/)&ast;
+* GxSD2Lead.lv2<sup>✝</sup> - Based on the [Boss SD-2 Dual Overdrive](http://www.bossarea.com/boss-sd-2-dual-overdrive/)&ast;
 
 #### Fuzz/Distortion
-* GxAxisFace.lv2<sup>✝</sup> - Based on the [Axis Face Silicon](http://fuzzcentral.ssguitar.com/axisface.php) fuzz
-* GxFz1b.lv2<sup>✝</sup> - Based on the Robert Moog-designed [Maestro FZ-1B](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone) fuzz
-* GxFz1s.lv2<sup>✝</sup> - Based on the [Maestro FZ-1S Super-Fuzz](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone)
-* GxHyperion.lv2 - Based on the Devi Ever FX Hyperion fuzz
-* GxHeathkit.lv2<sup>✝</sup> - Based on the [Heathkit TA-28](http://harmony.demont.net/heathkit.php) distortion/booster/fuzz
-* GxKnightFuzz.lv2<sup>✝</sup> - Based on the [Basic Audio Knight Fuzz](http://www.basicaudio.net/pedal-details.php?pedal=30) fuzz
-* GxLiquidDrive.lv2<sup>✝</sup> - Based on the [Liquid Drive](http://fuzzcentral.ssguitar.com/liquid.php) fuzz, a modified [Ross Distortion](http://www.home-wrecker.com/ross.html)
-* GxSuppaToneBender.lv2 - Based on the [Colorsound Supa Tonebender](https://en.wikipedia.org/wiki/Tone_Bender) which, in turn, is based on the [Electro-Harmonix Big Muff π](https://en.wikipedia.org/wiki/Big_Muff)
-* GxSaturator.lv2 - Based on the Joe Satriani-specified [Vox Satchurator](https://www.joesatrianiuniverse.com/gear/vox-js-pedals/satchurator/) distortion
-* GxSunFace.lv2<sup>✝</sup> - Based on the [Analog Man Sun Face](http://www.analogman.com/fuzzface.htm) fuzz
-* GxSuperFuzz.lv2 - Based on the [Univox Super-Fuzz](https://en.wikipedia.org/wiki/Univox_Super-Fuzz)
-* GxToneMachine.lv2 - Based on the [Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm) fuzz
+* GxAxisFace.lv2<sup>✝</sup> - Based on the [Axis Face Silicon](http://fuzzcentral.ssguitar.com/axisface.php)&ast; fuzz
+* GxFz1b.lv2<sup>✝</sup> - Based on the Robert Moog-designed [Maestro FZ-1B](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone)&ast; fuzz
+* GxFz1s.lv2<sup>✝</sup> - Based on the [Maestro FZ-1S Super-Fuzz](https://en.wikipedia.org/wiki/Maestro_FZ-1_Fuzz-Tone)&ast;
+* GxHyperion.lv2 - Based on the Devi Ever FX Hyperion&ast; fuzz
+* GxHeathkit.lv2<sup>✝</sup> - Based on the [Heathkit TA-28](http://harmony.demont.net/heathkit.php)&ast; distortion/booster/fuzz
+* GxKnightFuzz.lv2<sup>✝</sup> - Based on the [Basic Audio Knight Fuzz](http://www.basicaudio.net/pedal-details.php?pedal=30)&ast; fuzz
+* GxLiquidDrive.lv2<sup>✝</sup> - Based on the [Liquid Drive](http://fuzzcentral.ssguitar.com/liquid.php)&ast; fuzz, a modified [Ross Distortion](http://www.home-wrecker.com/ross.html)&ast;
+* GxSuppaToneBender.lv2 - Based on the [Colorsound Supa Tonebender](https://en.wikipedia.org/wiki/Tone_Bender)&ast; which, in turn, is based on the [Electro-Harmonix Big Muff π](https://en.wikipedia.org/wiki/Big_Muff)&ast;
+* GxSaturator.lv2 - Based on the Joe Satriani-specified [Vox Satchurator](https://www.joesatrianiuniverse.com/gear/vox-js-pedals/satchurator/)&ast; distortion
+* GxSunFace.lv2<sup>✝</sup> - Based on the [Analog Man Sun Face](http://www.analogman.com/fuzzface.htm)&ast; fuzz
+* GxSuperFuzz.lv2 - Based on the [Univox Super-Fuzz](https://en.wikipedia.org/wiki/Univox_Super-Fuzz)&ast;
+* GxToneMachine.lv2 - Based on the [Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm)&ast; fuzz
 * GxTubeDistortion.lv2<sup>✝</sup> - Generic tube distortion based on http://www.montagar.com/~patj/tubedist.gif
-* GxVintageFuzzMaster.lv2 - Based on the Devi Ever Vintage Fuzz Master
-* GxVoodoFuzz.lv2 - Based on the [Voodoo Lab SuperFuzz](http://www.voodoolab.com/superfuzz.htm). It's basically a Bosstone circuit, followed by the tone control of the [Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm) in parralel with a [Devi Ever Dark Boost](https://reverb.com/p/devi-ever-fx-dark-boost).
+* GxVintageFuzzMaster.lv2 - Based on the Devi Ever Vintage Fuzz Master&ast;
+* GxVoodoFuzz.lv2 - Based on the [Voodoo Lab SuperFuzz](http://www.voodoolab.com/superfuzz.htm)&ast;. It's basically a Bosstone&ast; circuit, followed by the tone control of the [Foxx Tone Machine](www.cbcpedals.com/product-p/tone-machine.htm)&ast; in parralel with a [Devi Ever Dark Boost](https://reverb.com/p/devi-ever-fx-dark-boost)&ast;.
 
 #### Amplifiers
 * GxMicroAmp.lv2<sup>✝</sup> - A simple booster 
-* GxVBassPreAmp.lv2<sup>✝</sup> - Simulation of the 1984 [Vox Venue Bass 100 Pre Amp](https://www.korguk.com/voxcircuits/) section
-* GxSVT.lv2<sup>✝</sup> - Based on the [Ampeg SVT-CL Bass Head](https://ampeg.com/products/classic/svtcl/) 
-* GxVmk2.lv2 - Based on Vox MKII solid state preamp of the late 60s
-* GxUvox720k - Based on [Vox-style amps](https://www.voxamps.com), probably the [JMI Vox UL730](http://www.voxshowroom.com/uk/amp/730.html)... need input from brummer
+* GxVBassPreAmp.lv2<sup>✝</sup> - Simulation of the 1984 [Vox Venue Bass 100 Pre Amp](https://www.korguk.com/voxcircuits/)&ast; section
+* GxSVT.lv2<sup>✝</sup> - Based on the [Ampeg SVT-CL Bass Head](https://ampeg.com/products/classic/svtcl/)&ast; 
+* GxVmk2.lv2 - Based on Vox MKII&ast; solid state preamp of the late 60s
+* GxUvox720k - Based on [Vox-style amps](https://www.voxamps.com)&ast;, probably the [JMI Vox UL730](http://www.voxshowroom.com/uk/amp/730.html)&ast;... need input from brummer
 
 #### Other
 * GxQuack.lv2<sup>✝</sup> - Autowah
-* GxSlowGear.lv2 - Based on the [Boss Gx SlowGear](http://www.bossarea.com/boss-sg-1-slow-gear/), attack-smoothing, auto-swelling pedal of the early 80s
+* GxSlowGear.lv2 - Based on the [Boss Gx SlowGear](http://www.bossarea.com/boss-sg-1-slow-gear/)&ast;, attack-smoothing, auto-swelling pedal of the early 80s
 
 ###### Build and installation
 


### PR DESCRIPTION
Three things:

1. Still need info about GxUVox720k

2. There are some dangling submodules not under this umbrella that need to be pulled in: GxCreamMachine, for example.

3. I have a decent amount of legal experience and the asterisk doesn't really do you any good in this situation. It's fine to say "based on" or "inspired by" or "simulation of"... the problem is you've included the trademark names in the module names themselves, e.g. HotBox, Hyperion, Dark Booster, etc. 

What you really should do is rename them something reminiscent of the real deal or more descriptive. Line 6 does this all the time: Spank = Stratocaster, Lester = Les Paul, Cali = Mesa, Brit = Marshall, etc.

So, just spitballing:
- GxVoodooFuzz→ GxWitchdoctorFuzz
- GxBottleRocket → GxRomanCandleOD
- GxSlowGear → GxSmoothingSweller
- GxGuvnor → GxBritTubeOD
- GxCreamMachine → GxTinyBritValveSim
- GxHeathkit → GxToffeebarFuzz
- GxLiquidDrive → GxThirstyDrive
etc