### PR TITLE
Build script for compiling on MSWin

### DIFF
--- a/README.mswin
+++ b/README.mswin
@@ -1,0 +1,19 @@
+The GxPlugins.lv2 plugins can be compiled as DSP-only plugins for MSWindows
+(i.e. only the effect part without a nice GUI)
+
+To compile the GxPlugins.lv2 LV2 plugins on MS-Windows:
+
+- Download and install MSYS2 from https://www.msys2.org/
+- Start a MinGW64 shell from the install location (e.g. "C:\MSYS64\MinGW64.exe")
+- Inside the shell, install the required packages using pacman:
+  # pacman -Syu
+  # pacman -S git make mingw-w64-x86_64-gcc mingw-w64-x86_64-lv2
+- Download the GxPlugins.lv2 sources and its submodules:
+  # git clone https://github.com/brummer10/GxPlugins.lv2.git
+  # cd GxPlugins.lv2
+  # git submodule init
+  # git submodule update
+- Build the plugins using the provided compile script:
+  # ./compile.mswin
+- The compiled plugins should show up in the "_bin/" folder inside the source directory
+- Untested: To compile 32bit versions, start the MinGW32 shell and install the 32bit libraries (in the pacman clause, replace all "mingw64" by "mingw32" and all "x86_64" by "i686")

--- a/compile.mswin
+++ b/compile.mswin
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo Patching Makefiles...
+find -name Makefile | while read MAKEFILE ; do
+  DIR=$(dirname $MAKEFILE)
+  [ "$DIR"x == "."x ] && continue
+  echo checking $MAKEFILE
+  # Create self-contained dynamic libraries with all dependencies statically linked in
+  # (replace -DPIC/-fPIC with -static). Also remove "-Wl,-z" options, which have no effect
+  # on MSWin (and break older MinGW gcc versions).
+  [ -e "${MAKEFILE}.mswin" ] \
+    || sed "s/-DPIC/-static/ ; s/-fPIC// ; s/-Wl,-z,relro,-z,now// ; s/-Wl,-z,noexecstack//" \
+         < "${MAKEFILE}" > "${MAKEFILE}.mswin"
+done
+
+echo Compiling Plugins
+export MAKE="make -f Makefile.mswin"
+make -j mod \
+  && make DESTDIR=$(pwd)/_bin install \
+  && echo Done. Plugins have been copied to $(pwd)/_bin


### PR DESCRIPTION
To compile these plugins for MSWin, only some linker flags needs to be changed.
The build script first patches the Makefiles to use the required linker options and then compiles the plugins.